### PR TITLE
[master] Form method of hidden input '_method' is preserved on next request

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.6-dev"
+            "dev-master": "5.6"
         },
         "laravel": {
             "providers": [

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -572,7 +572,7 @@ class FormBuilder
      *
      * @param  string $name
      * @param  array  $list
-     * @param  string $selected
+     * @param  string|bool $selected
      * @param  array  $selectAttributes
      * @param  array  $optionsAttributes
      * @param  array  $optgroupsAttributes
@@ -787,7 +787,9 @@ class FormBuilder
         } elseif ($selected instanceof Collection) {
             return $selected->contains($value) ? 'selected' : null;
         }
-
+        if (is_int($value) && is_bool($selected)) {
+            return (bool)$value === $selected;
+        }
         return ((string) $value === (string) $selected) ? 'selected' : null;
     }
 

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -464,6 +464,12 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
             '<select name="countries"><option value="1" selected="selected">L</option><option value="2">M</option></select>',
             $result
         );
+
+        $select = $this->formBuilder->select('avc', [1 => 'Yes', 0 => 'No'], true, ['placeholder' => 'Select']);
+        $this->assertEquals(
+            '<select name="avc"><option value="" hidden="hidden">Select</option><option value="1" selected>Yes</option><option value="0" >No</option></select>',
+            $select
+        );
     }
 
     public function testSelectCollection()


### PR DESCRIPTION
_FYI: This pull request was already merged in the [5.4](https://github.com/LaravelCollective/html/tree/5.4), 5.5 and 5.6 branches but not in the [master](https://github.com/LaravelCollective/html/tree/master) branch_

E.G. when you submit a form with a `PATCH` method and then you submit another form which use a `DELETE` method instead, the [`FormBuilder::getValueAttribute()`](https://github.com/LaravelCollective/html/blob/f905913a3ab7ca639b69138aab28baa01d400034/src/FormBuilder.php#L1135) method use the previous value of the hidden input `_method` attribute.
So the value is replaced by `PATCH` instead of the desired `DELETE` value.

Maybe related to https://github.com/LaravelCollective/html/issues/350#issuecomment-309899542

PS: I use AJAX/XHR to submit my forms.
So I don't have any HTTP redirection between my two forms submit, just DOM replacements on the Browser

_The original pull request for Laravel 5.4 is [here](https://github.com/LaravelCollective/html/pull/395)_
_The pull request for Laravel 5.5 is [here](https://github.com/LaravelCollective/html/pull/460)_
_And the pull request for Laravel 5.6 is [here](https://github.com/LaravelCollective/html/pull/486)_